### PR TITLE
Update setup.py

### DIFF
--- a/pytorch/setup.py
+++ b/pytorch/setup.py
@@ -17,7 +17,7 @@ setup(name='nnunet',
             "scipy",
             "batchgenerators>=0.21",
             "numpy",
-            "sklearn",
+            "scikit-learn",
             "SimpleITK",
             "pandas",
             "nibabel", 'tifffile'

--- a/pytorch/setup.py
+++ b/pytorch/setup.py
@@ -17,7 +17,6 @@ setup(name='nnunet',
             "scipy",
             "batchgenerators>=0.21",
             "numpy",
-            "scikit-learn",
             "SimpleITK",
             "pandas",
             "nibabel", 'tifffile'


### PR DESCRIPTION
 The 'sklearn' PyPI package is deprecated, use 'scikit-learn' rather than 'sklearn' for pip commands.
      